### PR TITLE
Fix: don't invert embed YouTube in dark mode

### DIFF
--- a/static/css/dark.css
+++ b/static/css/dark.css
@@ -10,6 +10,7 @@ body {
 }
 img,
 video,
+iframe,
 body * [style*="background-image"] {
   filter: hue-rotate(180deg) contrast(100%) invert(100%);
   -webkit-filter: hue-rotate(180deg) contrast(100%) invert(100%);


### PR DESCRIPTION
Hi Bino,

This commit fixes an issue with color inversion of an embed YouTube in dark mode, as for example:

{{< youtube id="Qic7q66zQ_4" >}}

Wojtek