### PR TITLE
fix: Card pictures position and border-radius

### DIFF
--- a/layouts/partials/post_preview.html
+++ b/layouts/partials/post_preview.html
@@ -1,6 +1,6 @@
 <div class="col-xl-4 col-lg-4 col-md-6 col-sm-6  mb-4">
     <div class="card h-100 single-post-card shadow-effect bg-faded-light">
-        <a href="{{ .Permalink }}">
+        <a class="card-flex" href="{{ .Permalink }}">
             <div class="card-body">
 
                 <h3 class="fw-bold post-title">{{ .Title }}</h3>
@@ -30,7 +30,7 @@
             </div>
 
             {{ if .Params.image }}
-            <img src="{{ .Params.image }}" alt="{{ .Title }}" class="card-img-top img-fluid">
+            <img src="{{ .Params.image }}" alt="{{ .Title }}" class="card-img-bottom">
             {{ end }}
             {{ if .Params.video }}
             <video loop autoplay muted playsinline class="img-title">

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -9,26 +9,29 @@ body {
   flex-flow: column;
   min-height: 100vh;
 }
+
 .container[role=main] {
-  margin-bottom:25px;
-  flex: 1 0 auto; 
+  margin-bottom: 25px;
+  flex: 1 0 auto;
 }
 
 @media only screen and (max-width: 767px) {
-.container[role=main] {
-    margin-left: 0;
-    margin-right: 0;
-}
+  .container[role=main] {
+    margin-left: auto;
+    margin-right: auto;
+  }
 }
 
 p {
   line-height: 1.5;
-  margin: 6px 0; 
+  margin: 6px 0;
 }
-p + p {
-    margin: 24px 0 6px 0;
+
+p+p {
+  margin: 24px 0 6px 0;
 }
-p a { 
+
+p a {
   color: #008AFF;
 }
 
@@ -38,22 +41,25 @@ li a {
 }
 
 a {
-  color: #4B4F56; 
+  color: #4B4F56;
   text-decoration: none;
 }
 
 a:hover,
 a:focus {
-  color: #4B4F56; 
+  color: #4B4F56;
   text-decoration: none;
 }
+
 blockquote {
   color: #808080;
   font-style: italic;
 }
+
 blockquote p:first-child {
   margin-top: 0;
 }
+
 hr.small {
   max-width: 100px;
   margin: 15px auto;
@@ -76,11 +82,13 @@ div.panel-body a.list-group-item {
   border: none;
   font-size: 16px;
 }
+
 div.panel-group .panel {
-    border-radius: 0;
+  border-radius: 0;
 }
+
 div.panel-group .panel+.panel {
-    margin-top: 0;
+  margin-top: 0;
 }
 
 div.panel-body a.list-group-item.view-all {
@@ -92,15 +100,18 @@ div.panel-body a.list-group-item.view-all {
   text-shadow: none;
   background: #ED1B2F;
 }
+
 ::selection {
   color: white;
   text-shadow: none;
   background: #ED1B2F;
 }
+
 img::selection {
   color: white;
   background: transparent;
 }
+
 img::-moz-selection {
   color: white;
   background: transparent;
@@ -116,14 +127,14 @@ img {
   width: 100%;
 }
 
-.img-50{
+.img-50 {
   max-width: 90px;
 }
 
-.img-round
-{
+.img-round {
   border-radius: 50%;
 }
+
 .disqus-comments {
   margin-top: 30px;
 }
@@ -138,7 +149,7 @@ img {
   height: 50vh;
 }
 
-.intro-header-custom{
+.intro-header-custom {
   margin-top: 20%;
 }
 
@@ -164,7 +175,7 @@ img {
 }
 
 .navbar-custom .navbar-brand:hover,
-.navbar-custom .navbar-brand:focus ,
+.navbar-custom .navbar-brand:focus,
 .navbar-custom .nav li a:hover,
 .navbar-custom .nav li a:focus {
   color: #ED1B2F;
@@ -176,15 +187,18 @@ img {
   -moz-transition: padding .5s ease-in-out;
   transition: padding .5s ease-in-out;
 }
+
 .navbar-custom .navbar-brand-logo img {
   height: 50px;
   -webkit-transition: height .5s ease-in-out;
   -moz-transition: height .5s ease-in-out;
   transition: height .5s ease-in-out;
 }
+
 .navbar-custom.top-nav-short .navbar-brand-logo {
   padding-top: 5px;
 }
+
 .navbar-custom.top-nav-short .navbar-brand-logo img {
   height: 40px;
 }
@@ -192,9 +206,9 @@ img {
 @media only screen and (min-width: 768px) {
   .navbar-custom {
     padding: 0px 0;
-    -webkit-transition: background .5s ease-in-out,padding .5s ease-in-out;
-    -moz-transition: background .5s ease-in-out,padding .5s ease-in-out;
-    transition: background .5s ease-in-out,padding .5s ease-in-out;
+    -webkit-transition: background .5s ease-in-out, padding .5s ease-in-out;
+    -moz-transition: background .5s ease-in-out, padding .5s ease-in-out;
+    transition: background .5s ease-in-out, padding .5s ease-in-out;
   }
 
   .navbar-custom.top-nav-short {
@@ -212,7 +226,8 @@ img {
   width: 50px;
   margin-top: -25px;
 }
-.navbar-custom .avatar-container  .avatar-img-border {
+
+.navbar-custom .avatar-container .avatar-img-border {
   width: 100%;
   border-radius: 50%;
   margin-left: -50%;
@@ -221,17 +236,18 @@ img {
   -webkit-box-shadow: 0 0 5px rgba(0, 0, 0, .8);
   -moz-box-shadow: 0 0 8px rgba(0, 0, 0, .8);
 }
-.navbar-custom .avatar-container  .avatar-img {
+
+.navbar-custom .avatar-container .avatar-img {
   width: 100%;
   border-radius: 50%;
   display: block;
 }
 
-.navbar-custom.top-nav-short .avatar-container{
+.navbar-custom.top-nav-short .avatar-container {
   opacity: 0;
 }
 
-.navbar-custom.top-nav-expanded .avatar-container  {
+.navbar-custom.top-nav-expanded .avatar-container {
   display: none;
 }
 
@@ -241,14 +257,14 @@ img {
     margin-top: -50px;
   }
 
-  .navbar-custom .avatar-container  .avatar-img-border {
+  .navbar-custom .avatar-container .avatar-img-border {
     width: 100%;
     box-shadow: 1px 1px 2px rgba(0, 0, 0, .8);
     -webkit-box-shadow: 1px 1px 2px rgba(0, 0, 0, .8);
     -moz-box-shadow: 1px 1px 2px rgba(0, 0, 0, .8);
   }
 
-  .navbar-custom .avatar-container  .avatar-img {
+  .navbar-custom .avatar-container .avatar-img {
     width: 100%;
   }
 }
@@ -257,14 +273,17 @@ img {
 .navbar-custom .nav .navlinks-container {
   position: relative;
 }
+
 .navbar-custom .nav .navlinks-parent:after {
   content: " \25BC";
 }
+
 .navbar-custom .nav .navlinks-children {
   width: 100%;
   display: none;
   word-break: break-word;
 }
+
 .navbar-custom .nav .navlinks-container .navlinks-children a {
   display: block;
   padding: 10px;
@@ -274,27 +293,34 @@ img {
   border-width: 0 1px 1px 1px;
   font-weight: normal;
 }
+
 @media only screen and (max-width: 767px) {
   .navbar-custom .nav .navlinks-container.show-children {
     background: #eee;
   }
+
   .navbar-custom .nav .navlinks-container.show-children .navlinks-children {
     display: block;
   }
 }
+
 @media only screen and (min-width: 768px) {
   .navbar-custom .nav .navlinks-container {
     text-align: center;
   }
+
   .navbar-custom .nav .navlinks-container:hover {
     background: #eee;
   }
+
   .navbar-custom .nav .navlinks-container:hover .navlinks-children {
     display: block;
   }
+
   .navbar-custom .nav .navlinks-children {
     position: absolute;
   }
+
   .navbar-custom .nav .navlinks-container .navlinks-children a {
     padding-left: 10px;
     border: 1px solid #eaeaea;
@@ -324,10 +350,12 @@ footer .list-inline {
   margin: 0;
   padding: 0;
 }
+
 footer .copyright {
   text-align: center;
   margin-bottom: 0;
 }
+
 footer .theme-by {
   text-align: center;
   margin: 10px 0 0;
@@ -337,9 +365,11 @@ footer .theme-by {
   footer {
     padding: 50px 0;
   }
+
   footer .footer-links {
     font-size: 18px;
   }
+
   footer .copyright {
     font-size: 16px;
   }
@@ -370,7 +400,7 @@ footer .theme-by {
 .post-preview a:focus,
 .post-preview a:hover {
   text-decoration: none;
-  color: #ED1B2F; 
+  color: #ED1B2F;
 }
 
 .post-preview .post-title {
@@ -378,14 +408,15 @@ footer .theme-by {
   margin-top: 0;
 }
 
-.post-title{
-  color : #344854
+.post-title {
+  color: #344854
 }
 
-.post-title:focus, .post-title:hover {
+.post-title:focus,
+.post-title:hover {
   text-decoration: none;
   color: #2ec458
-  /* #FF0000;  */
+    /* #FF0000;  */
 }
 
 .post-preview .post-subtitle {
@@ -393,6 +424,7 @@ footer .theme-by {
   font-weight: 300;
   margin-bottom: 10px;
 }
+
 .post-preview .post-meta,
 .post-heading .post-meta,
 .page-meta {
@@ -401,16 +433,19 @@ footer .theme-by {
   font-style: italic;
   margin: 0 0 10px;
 }
+
 .page-meta {
   align-self: center;
 }
+
 .post-preview .post-meta a,
 .post-heading .post-meta a,
 .page-meta a {
   color: #404040;
   text-decoration: none;
 }
-.post-meta{
+
+.post-meta {
   color: #808080;
   font-size: 13px;
   font-style: italic;
@@ -421,11 +456,13 @@ footer .theme-by {
   display: inline-block;
   width: 100%;
 }
+
 .post-entry {
   width: 100%;
   margin-top: 10px;
   /* color: #4B4F56;  */
 }
+
 .post-image {
   float: right;
   height: 192px;
@@ -433,14 +470,17 @@ footer .theme-by {
   margin-top: -35px;
   filter: grayscale(90%);
 }
+
 .post-image:hover {
   filter: grayscale(0%);
 }
+
 .post-image img {
   border-radius: 100px;
   height: 192px;
   width: 192px;
 }
+
 .post-preview .post-read-more {
   font-weight: 800;
   float: right;
@@ -456,7 +496,7 @@ footer .theme-by {
 
 .blog-tags {
   color: #999;
-  font-size: 15px; 
+  font-size: 15px;
 }
 
 /* .blog-tags:before {
@@ -491,7 +531,9 @@ footer .theme-by {
 }
 
 @media only screen and (max-width: 500px) {
-  .post-image, .post-image img {
+
+  .post-image,
+  .post-image img {
     height: 100px;
     width: 100px;
   }
@@ -503,6 +545,7 @@ footer .theme-by {
     float: left;
   }
 }
+
 /* --- Post and page headers --- */
 
 .intro-header {
@@ -510,16 +553,19 @@ footer .theme-by {
   position: relative;
   margin-top: 130px;
 }
+
 .intro-header.big-img {
   background: no-repeat center center;
   -webkit-background-size: cover;
   -moz-background-size: cover;
   background-size: cover;
   -o-background-size: cover;
-  margin-top: 51px; /* The small navbar is 50px tall + 1px border */
+  margin-top: 51px;
+  /* The small navbar is 50px tall + 1px border */
   margin-bottom: 35px;
 }
-.intro-header.big-img  .big-img-transition {
+
+.intro-header.big-img .big-img-transition {
   position: absolute;
   width: 100%;
   height: 100%;
@@ -533,27 +579,32 @@ footer .theme-by {
   -moz-transition: opacity 1s linear;
   transition: opacity 1s linear;
 }
+
 .intro-header .page-heading,
 .intro-header .tags-heading,
 .intro-header .categories-heading {
   text-align: center;
 }
+
 .intro-header.big-img .page-heading,
 .intro-header.big-img .post-heading {
   padding: 100px 0;
   color: #FFF;
   text-shadow: 1px 1px 3px #000;
 }
+
 .intro-header .page-heading h1,
 .intro-header .tags-heading h1,
 .intro-header .categories-heading h1 {
   margin-top: 0;
   /* font-size: 50px; */
 }
+
 .intro-header .post-heading h1 {
   margin-top: 0;
   font-size: 35px;
 }
+
 .intro-header .page-heading .page-subheading,
 .intro-header .post-heading .post-subheading {
   font-size: 27px;
@@ -562,21 +613,26 @@ footer .theme-by {
   font-weight: 300;
   margin: 10px 0 0;
 }
+
 .intro-header .post-heading .post-subheading {
   margin-bottom: 20px;
 }
+
 .intro-header.big-img .page-heading .page-subheading,
 .intro-header.big-img .post-heading .post-subheading {
   font-weight: 400;
 }
+
 .intro-header.big-img .page-heading hr {
   box-shadow: 1px 1px 3px #000;
   -webkit-box-shadow: 1px 1px 3px #000;
   -moz-box-shadow: 1px 1px 3px #000;
 }
+
 .intro-header.big-img .post-heading .post-meta {
   color: #EEE;
 }
+
 .intro-header.big-img .img-desc {
   background: rgba(30, 30, 30, 0.6);
   position: absolute;
@@ -595,6 +651,7 @@ footer .theme-by {
   padding: 20px 0;
   box-shadow: 0 0 5px #AAA;
 }
+
 .caption {
   text-align: center;
   font-size: 14px;
@@ -608,7 +665,7 @@ footer .theme-by {
 
 
 .page-caption {
-  text-align: center; 
+  text-align: center;
   font-weight: 500;
   padding: 10px;
   margin: 0;
@@ -629,11 +686,13 @@ footer .theme-by {
   border-radius: 0;
   color: #404040;
 }
+
 @media only screen and (min-width: 768px) {
   .pager li a {
     padding: 15px 25px;
   }
 }
+
 .pager li a:hover,
 .pager li a:focus {
   color: #FFF;
@@ -646,15 +705,15 @@ footer .theme-by {
 }
 
 .pager.blog-pager {
-  margin-top:10px;
+  margin-top: 10px;
 }
 
-h4.panel-title > span.badge {
-    float: right;
+h4.panel-title>span.badge {
+  float: right;
 }
 
 @media only screen and (min-width: 768px) {
-  .pager.blog-pager  {
+  .pager.blog-pager {
     margin-top: 40px;
   }
 }
@@ -664,15 +723,18 @@ h4.panel-title > span.badge {
 table {
   padding: 0;
 }
+
 table tr {
   border-top: 1px solid #cccccc;
   background-color: #ffffff;
   margin: 0;
   padding: 0;
 }
+
 table tr:nth-child(2n) {
   background-color: #f8f8f8;
 }
+
 table tr th {
   font-weight: bold;
   border: 1px solid #cccccc;
@@ -680,16 +742,19 @@ table tr th {
   margin: 0;
   padding: 6px 13px;
 }
+
 table tr td {
   border: 1px solid #cccccc;
   text-align: left;
   margin: 0;
   padding: 6px 13px;
 }
+
 table tr th :first-child,
 table tr td :first-child {
   margin-top: 0;
 }
+
 table tr th :last-child,
 table tr td :last-child {
   margin-bottom: 0;
@@ -702,44 +767,66 @@ table tr td :last-child {
 }
 
 /* --- Google Custom Search Engine Popup --- */
-#modalSearch table tr, #modalSearch table tr td, #modalSearch table tr th {
-  border:none;
+#modalSearch table tr,
+#modalSearch table tr td,
+#modalSearch table tr th {
+  border: none;
 }
-.reset-box-sizing, .reset-box-sizing *, .reset-box-sizing *:before, .reset-box-sizing *:after,  .gsc-inline-block {
+
+.reset-box-sizing,
+.reset-box-sizing *,
+.reset-box-sizing *:before,
+.reset-box-sizing *:after,
+.gsc-inline-block {
   -webkit-box-sizing: content-box;
   -moz-box-sizing: content-box;
   box-sizing: content-box;
 }
-input.gsc-input, .gsc-input-box, .gsc-input-box-hover, .gsc-input-box-focus, .gsc-search-button {
+
+input.gsc-input,
+.gsc-input-box,
+.gsc-input-box-hover,
+.gsc-input-box-focus,
+.gsc-search-button {
   box-sizing: content-box;
   line-height: normal;
 }
 
 /* IPython split style */
-div.splitbox {width:100%; overflow:auto;}
+div.splitbox {
+  width: 100%;
+  overflow: auto;
+}
 
 div.splitbox div.left {
-               width:48%;
-               float:left;}
+  width: 48%;
+  float: left;
+}
+
 div.splitbox div.right {
-               width:48%;
-               float:right;}
+  width: 48%;
+  float: right;
+}
 
 @media only screen and (max-width: 600px) {
-div.splitbox div.left {
-               width:100%;
-               float:left;}
-div.splitbox div.right {
-               width:100%;
-               float:left;}
+  div.splitbox div.left {
+    width: 100%;
+    float: left;
+  }
+
+  div.splitbox div.right {
+    width: 100%;
+    float: left;
+  }
 }
+
 /* Related posts */
 h4.see-also {
   margin-top: 20px;
 }
 
 /* Sharing */
- ul.share {
+ul.share {
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
@@ -747,128 +834,131 @@ h4.see-also {
   margin: 0;
   padding: 0;
 }
- ul.share li {
+
+ul.share li {
   display: inline-flex;
   margin-right: 25px;
 }
- ul.share li:last-of-type {
+
+ul.share li:last-of-type {
   margin-right: 0;
 }
- ul.share li .fab {
+
+ul.share li .fab {
   display: block;
   width: 35px;
   height: 35px;
   line-height: 35px;
   font-size: 25px;
   text-align: center;
-  transition: all 150ms ease-in-out; 
+  transition: all 150ms ease-in-out;
 }
 
- ul.share li:hover .fab {
+ul.share li:hover .fab {
   transform: scale(1.4)
 }
 
-.facebook-color{
-  color:#3b5998;
+.facebook-color {
+  color: #3b5998;
 }
 
-.twitter-color{
+.twitter-color {
   color: #1DA1F2;
 }
 
-.whatsapp-color{
+.whatsapp-color {
   color: #25D366;
 }
 
-.reddit-color{
+.reddit-color {
   color: #FF4500;
 }
 
-.linkedin-color{
+.linkedin-color {
   color: #0E76A8;
 }
 
-.pinterest-color{
+.pinterest-color {
   color: #c8232c;
 }
 
 /***/
 
 /* so font style */
-.fw-500{
+.fw-500 {
   font-weight: 500;
 }
 
 /* eo font style */
 
-.navbar{
-    box-shadow:0px 2px 20px 0px rgba(0,0,0,0.08);
-    background-color :rgba(255,255,255,.98); 
-    z-index: 9999;
+.navbar {
+  box-shadow: 0px 2px 20px 0px rgba(0, 0, 0, 0.08);
+  background-color: rgba(255, 255, 255, .98);
+  z-index: 9999;
 }
 
-.navbar-brand{
+.navbar-brand {
   font-size: 1.5rem;
 }
 
-.nav-link{
-  background-color :rgba(255,255,255,.98);
+.nav-link {
+  background-color: rgba(255, 255, 255, .98);
 }
 
 .bg-faded-light {
- background-color: #FFFFFF;
+  background-color: #FFFFFF;
 }
 
-.bg-black{
+.bg-black {
   background-color: #F9F9F9;
-/* background-image: linear-gradient(315deg, #b8c6db 0%, #f5f7fa 74%); */
+  /* background-image: linear-gradient(315deg, #b8c6db 0%, #f5f7fa 74%); */
 }
 
 
-.home-head-banner{  
+.home-head-banner {
   display: flex;
   align-items: center;
   justify-content: center;
   height: 100%;
   background-color: #ffffff;
-  background-attachment: fixed;  
+  background-attachment: fixed;
 }
 
-.home-intro-section{
-  color:#4B4F56;
+.home-intro-section {
+  color: #4B4F56;
   background-color: #F6F4F1;
   font-weight: 500;
-  padding:5% 0 5% 0;
+  padding: 5% 0 5% 0;
 }
 
-.img-80{
+.img-80 {
   max-width: 80%;
 }
 
-.img-40{
+.img-40 {
   max-width: 40%;
 }
 
-.single-post-card{
+.single-post-card {
   background-color: white;
-  text-align: left; 
-  box-shadow: 0 20px 20px rgba(0,0,0,.08);
-  white-space: normal; 
+  text-align: left;
+  box-shadow: 0 20px 20px rgba(0, 0, 0, .08);
+  white-space: normal;
   color: #4B4F56;
   border: 0px;
   margin: 0 2%;
   -webkit-transition: all 250ms cubic-bezier(.02, .01, .47, 1);
   -moz-transition: all 250ms cubic-bezier(.02, .01, .47, 1);
   transition: all 250ms cubic-bezier(.02, .01, .47, 1);
-  transition-delay: 0s;  
+  transition-delay: 0s;
 }
 
-.single-post-card-haiku{
+.single-post-card-haiku {
   background-color: white;
   text-align: left;
   min-height: 400px;
   margin: 3%;
-  box-shadow: 0 20px 20px rgba(0,0,0,.08);
+  box-shadow: 0 20px 20px rgba(0, 0, 0, .08);
   white-space: normal;
   color: #4B4F56;
   /* border: 0px ; */
@@ -876,18 +966,27 @@ h4.see-also {
   -webkit-transition: all 250ms cubic-bezier(.02, .01, .47, 1);
   -moz-transition: all 250ms cubic-bezier(.02, .01, .47, 1);
   transition: all 250ms cubic-bezier(.02, .01, .47, 1);
-  transition-delay: 0s; 
+  transition-delay: 0s;
 }
 
 /* Transform commented to avoid jumping transition when hovering cards */
 
 .single-post-card:hover {
-  box-shadow: 0 40px 40px 
-  rgba(0,0,0,.16);
+  box-shadow: 0 40px 40px rgba(0, 0, 0, .16);
   transition-delay: 0s !important;
   /* transform: translate(0,-20px); */
 }
 
+.main .row {
+  justify-content: center;
+}
+
+.card-flex {
+  display: flex;
+  flex-flow: column nowrap;
+  justify-content: space-between;
+  height: 100%;
+}
 
 .card-image {
   width: 100%;
@@ -899,29 +998,30 @@ h4.see-also {
 }
 
 
-.feature-image .carousel-caption{
-  left: 5%;   
+.feature-image .carousel-caption {
+  left: 5%;
   right: unset;
   top: 0;
 }
 
-.shadow-effect{
-  box-shadow: 0 20px 20px rgba(0,0,0,.08);
+.shadow-effect {
+  box-shadow: 0 20px 20px rgba(0, 0, 0, .08);
 }
 
-.pl-0{
+.pl-0 {
   padding-left: 0;
 }
 
-.b-0{
-  border : 0px;
+.b-0 {
+  border: 0px;
 }
 
-.read-more-section{
+.read-more-section {
   padding-top: 3%;
 }
 
-.card-image-blog{
+
+.card-image-blog {
   height: 100%;
 }
 
@@ -929,7 +1029,7 @@ h4.see-also {
   font-family: sans-serif !important;
 }
 
-.page-link{
+.page-link {
   color: #23272B;
   line-height: 0.75;
   font-size: 18px;
@@ -947,12 +1047,12 @@ h4.see-also {
   color: #23272B;
 }
 
- /* Style the header: fixed position (always stay at the top) */
- .header {
+/* Style the header: fixed position (always stay at the top) */
+.header {
   position: fixed;
   top: 0;
   z-index: 99999;
-  width: 100%; 
+  width: 100%;
 }
 
 /* The progress container (grey background) */
@@ -967,16 +1067,16 @@ h4.see-also {
   height: 8px;
   background: #4caf50;
   width: 0%;
-} 
+}
 
-.h-30{
+.h-30 {
   height: 7.5rem;
 }
 
-.fs-1{
+.fs-1 {
   font-size: 1.1rem;
 }
 
-.flex-row{
+.flex-row {
   flex-direction: row;
 }


### PR DESCRIPTION
Fixes:

Pictures in cards have `border-radius` set at the bottom instead of top (changed the respective bootstrap class):

<img width="369" alt="Capture d’écran 2023-07-27 à 01 47 14" src="https://github.com/binokochumolvarghese/lightbi-hugo/assets/105607989/d9685550-7661-41dd-ac4b-89966632aa67">

Pictures now stick to the bottom of the card instead of its previous sibling, moving whitespace at the bottom of smaller cards of a row, to the space between the picture and the text:

<img width="1110" alt="Capture d’écran 2023-07-27 à 01 46 23" src="https://github.com/binokochumolvarghese/lightbi-hugo/assets/105607989/fe913042-650f-463d-bcfd-1f52f870d128">

On fold-like sizes, cards are centered like other biggers sizes (was left aligned):

![ezgif-4-f608f4c67a](https://github.com/binokochumolvarghese/lightbi-hugo/assets/105607989/930bdc36-6806-4065-a379-55ad1e1cb28a)
