### PR TITLE
Improve German translation, allow multiple forms for "minutes" and "words"

### DIFF
--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -18,22 +18,26 @@
 - id: newerPosts
   translation: "Neuere Posts"
 - id: previousPost
-  translation: "Letzter Post"
+  translation: "Vorheriger Post"
 - id: nextPost
   translation: "Nächster Post"
 - id: readTime
-  translation: "Minuten"
+  translation:
+    one: "Minute"
+    other: "Minuten"
 - id: words
-  translation: "Wörter"
+  translation:
+    one: "Wort"
+    other: "Wörter"
 
 
 # 404 page
 - id: pageNotFound
-  translation: "Ups, diese Seite existiert nicht. (404 Error)"
+  translation: "Ups, diese Seite existiert nicht. (404 Fehler)"
 
 # Footer
 - id: poweredBy # Accepts HTML
-  translation: 'Powered by <a href="https://gohugo.io">Hugo</a> & <a href="https://github.com/binokochumolvarghese/lightbi-hugo">Lightbi.</a>&nbsp; Made with ❤ by <a href="https://binovarghese.com">Bino</a>'
+  translation: 'Erstellt mit <a href="https://gohugo.io">Hugo</a> & <a href="https://github.com/binokochumolvarghese/lightbi-hugo">Lightbi.</a>&nbsp; Mit ❤ gemacht von <a href="https://binovarghese.com">Bino</a>'
 
 # Navigation
 - id: toggleNavigation
@@ -43,7 +47,7 @@
 - id: gcseLabelShort
   translation: "Suche"
 - id: gcseLabelLong
-  translation: "Suche {{ .Site.Title }}"
+  translation: "{{ .Site.Title }} durchsuchen"
 - id: gcseClose
   translation: "Schließen"
 
@@ -67,7 +71,7 @@
 - id: show
   translation: "Zeige"
 - id: comments
-  translation: "Kommentare" 
+  translation: "Kommentare"
 
 # Related posts
 - id: seeAlso

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -22,9 +22,13 @@
 - id: nextPost
   translation: "Next Post"
 - id: readTime
-  translation: "minutes"
+  translation:
+    one: "minute"
+    other: "minutes"
 - id: words
-  translation: "words"
+  translation:
+    one: "word"
+    other: "words"
 
 
 # 404 page
@@ -67,7 +71,7 @@
 - id: show
   translation: "Show"
 - id: comments
-  translation: "comments" 
+  translation: "comments"
 
 # Related posts
 - id: seeAlso

--- a/layouts/partials/post_meta.html
+++ b/layouts/partials/post_meta.html
@@ -1,17 +1,17 @@
 <span class="post-meta">
   {{ $lastmodstr := default (i18n "dateFormat") .Site.Params.dateformat | .Lastmod.Format }}
   {{ $datestr := default (i18n "dateFormat") .Site.Params.dateformat | .Date.Format }}
-  &nbsp;{{ $datestr  }} 
+  &nbsp;{{ $datestr  }}
 
   {{ if .Site.Params.readingTime }}
-    &nbsp;|&nbsp;<i class="fas fa-clock"></i>&nbsp;{{ i18n "readingTime"}}{{ .ReadingTime }}&nbsp;{{ i18n "readTime" }}
+    &nbsp;|&nbsp;<i class="fas fa-clock"></i>&nbsp;{{ i18n "readingTime"}}{{ .ReadingTime }}&nbsp;{{ i18n "readTime" .ReadingTime }}
   {{ end }}
 
   {{ if .Site.Params.wordCount }}
-    &nbsp;|&nbsp;<i class="fas fa-book"></i>&nbsp;{{ .WordCount }}&nbsp;{{ i18n "words" }}
+    &nbsp;|&nbsp;<i class="fas fa-book"></i>&nbsp;{{ .WordCount }}&nbsp;{{ i18n "words" .WordCount }}
   {{ end }}
-  
- 
+
+
 
   {{- if .Site.Params.staticman -}}
     &nbsp;|&nbsp;<i class="fas fa-comment"></i>&nbsp;
@@ -29,7 +29,7 @@
       {{ end }}
     {{ end }}
   {{ end }}
-  
+
   {{ if .IsTranslated -}}
     {{- $sortedTranslations := sort .Translations "Site.Language.Weight" -}}
     {{- $links := apply $sortedTranslations "partial" "translation_link.html" "." -}}

--- a/layouts/partials/post_meta_notes.html
+++ b/layouts/partials/post_meta_notes.html
@@ -9,11 +9,11 @@
   {{ end }}
 
   {{ if .Site.Params.readingTime }}
-  &nbsp;|&nbsp; <i class="bi bi-clock"></i>&nbsp;{{ i18n "readingTime"}}{{ .ReadingTime }}&nbsp;{{ i18n "readTime" }}
+  &nbsp;|&nbsp; <i class="bi bi-clock"></i>&nbsp;{{ i18n "readingTime"}}{{ .ReadingTime }}&nbsp;{{ i18n "readTime" .ReadingTime }}
   {{ end }}
 
   {{ if .Site.Params.wordCount }}
-  &nbsp;|&nbsp;<i class="bi bi-book"></i>&nbsp;{{ .WordCount }}&nbsp;{{ i18n "words" }}
+  &nbsp;|&nbsp;<i class="bi bi-book"></i>&nbsp;{{ .WordCount }}&nbsp;{{ i18n "words" .WordCount }}
   {{ end }}
 
   {{ if .IsTranslated -}}


### PR DESCRIPTION
Some strings in the German translations haven’t been translated correctly, I fixed it. Also, Hugo [allows translations to have different singular and plural forms](https://gohugo.io/functions/lang/translate/), using this for “minutes” and “words” in both English and German.

Sorry about all the whitespace changes, the editor removes trailing whitespace automatically.