### PR TITLE
Make sure "Read more" string is consistently translated

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -68,7 +68,7 @@
             </div>
           </div>
 
-         
+
           <div class="col-md-10">
             <div class="card-body p-1.1">
               <p class="p-0 m-0"><small class="text-muted">Written By</small></p>
@@ -80,7 +80,7 @@
                 {{ .Site.Author.name | safeHTML }}
                 {{ end }}
 
-              </p> 
+              </p>
               {{ if .Site.Params.authorInfo }}
               <p class="card-text fs-6  m-0">{{ .Site.Params.authorInfo | safeHTML }}</p>
               {{ end }}
@@ -124,7 +124,7 @@
   <div class="container">
     <div class="row">
       <div class="col-lg-12 col-md-12 mt-3">
-        <h3>Read more</h3>
+        <h3>{{ i18n "readMore" }}</h3>
         <hr />
       </div>
 

--- a/layouts/partials/post_meta_notes.html
+++ b/layouts/partials/post_meta_notes.html
@@ -5,7 +5,7 @@
   {{ $datestr }}
 
   {{ if ne $datestr $lastmodstr }}
-  | &nbsp;Last Modified On: {{ $lastmodstr }}
+  {{ i18n "lastModified" $lastmodstr }}
   {{ end }}
 
   {{ if .Site.Params.readingTime }}

--- a/layouts/partials/post_preview_bottom_card.html
+++ b/layouts/partials/post_preview_bottom_card.html
@@ -26,8 +26,8 @@
 
                 <div class="read-more-section">
                     <!-- post-read-more  -->
-                    <h6><a href="{{ .Permalink }}" class="text-muted link-underline" alt="Link to {{ .Title }}">Read
-                            more <i class="bi bi-arrow-right"></i></a> </h6>
+                    <h6><a href="{{ .Permalink }}" class="text-muted link-underline" alt="Link to {{ .Title }}">{{ i18n "readMore" }}
+                            <i class="bi bi-arrow-right"></i></a> </h6>
                 </div>
             </div>
 

--- a/layouts/partials/post_preview_bottom_card.html
+++ b/layouts/partials/post_preview_bottom_card.html
@@ -1,6 +1,6 @@
 <div class="col-xl-4 col-lg-4 col-md-6 col-sm-6  mb-4">
     <div class="card h-100 single-post-card shadow-effect bg-faded-light border">
-        <a href="{{ .Permalink }}" alt="Link to {{ .Title }}">
+        <a href="{{ .Permalink }}">
             <div class="card-body">
 
                 <h3 class="fw-bold post-title">{{ .Title }}</h3>
@@ -26,8 +26,7 @@
 
                 <div class="read-more-section">
                     <!-- post-read-more  -->
-                    <h6><a href="{{ .Permalink }}" class="text-muted link-underline" alt="Link to {{ .Title }}">{{ i18n "readMore" }}
-                            <i class="bi bi-arrow-right"></i></a> </h6>
+                    <h6 class="text-muted link-underline">{{ i18n "readMore" }} <i class="bi bi-arrow-right"></i></h6>
                 </div>
             </div>
 

--- a/layouts/partials/post_preview_imgless_card.html
+++ b/layouts/partials/post_preview_imgless_card.html
@@ -1,6 +1,6 @@
 <div class="col-xl-4 col-lg-4 col-md-6 col-sm-6  mb-4">
     <div class="card h-100 single-post-card shadow-effect bg-faded-light border">
-        <a href="{{ .Permalink }}" alt="Link to {{ .Title }}">
+        <a href="{{ .Permalink }}">
             <div class="card-body">
 
                 <h3 class="fw-bold post-title">{{ .Title }}</h3>
@@ -24,8 +24,7 @@
                     {{ end }}
                 </div>
                 <div class="read-more-section">
-                    <h6><a href="{{ .Permalink }}" class="text-muted link-underline" alt="Link to {{ .Title }}">{{ i18n "readMore" }} <i
-                        class="bi bi-arrow-right"></i></a> </h6>
+                    <h6 class="text-muted link-underline">{{ i18n "readMore" }} <i class="bi bi-arrow-right"></i></h6>
                 </div>
             </div>
         </a>

--- a/layouts/partials/post_preview_imgless_card.html
+++ b/layouts/partials/post_preview_imgless_card.html
@@ -24,11 +24,11 @@
                     {{ end }}
                 </div>
                 <div class="read-more-section">
-                    <h6><a href="{{ .Permalink }}" class="text-muted link-underline" alt="Link to {{ .Title }}">Read more <i
+                    <h6><a href="{{ .Permalink }}" class="text-muted link-underline" alt="Link to {{ .Title }}">{{ i18n "readMore" }} <i
                         class="bi bi-arrow-right"></i></a> </h6>
                 </div>
             </div>
         </a>
         </a>
     </div>
-</div> 
+</div>

--- a/layouts/partials/post_preview_list.html
+++ b/layouts/partials/post_preview_list.html
@@ -22,7 +22,7 @@
                     {{ end }}
                 </div>
                 <div class="read-more-section">
-                    <h6><a href="{{ .Permalink }}" class="text-muted link-underline" alt="Link to {{ .Title }}">Read more <i
+                    <h6><a href="{{ .Permalink }}" class="text-muted link-underline" alt="Link to {{ .Title }}">{{ i18n "readMore" }} <i
                         class="bi bi-arrow-right"></i></a> </h6>
                 </div>
             </div>

--- a/layouts/partials/post_preview_list.html
+++ b/layouts/partials/post_preview_list.html
@@ -22,8 +22,7 @@
                     {{ end }}
                 </div>
                 <div class="read-more-section">
-                    <h6><a href="{{ .Permalink }}" class="text-muted link-underline" alt="Link to {{ .Title }}">{{ i18n "readMore" }} <i
-                        class="bi bi-arrow-right"></i></a> </h6>
+                    <h6 class="text-muted link-underline">{{ i18n "readMore" }} <i class="bi bi-arrow-right"></i></h6>
                 </div>
             </div>
         </div>

--- a/layouts/partials/post_preview_top_img_cards.html
+++ b/layouts/partials/post_preview_top_img_cards.html
@@ -42,7 +42,7 @@
                 </div>
 
                 <div class="read-more-section">
-                    <h6><a href="{{ .Permalink }}" class="text-muted link-underline" alt="Link to {{ .Title }}">Read more <i
+                    <h6><a href="{{ .Permalink }}" class="text-muted link-underline" alt="Link to {{ .Title }}">{{ i18n "readMore" }} <i
                         class="bi bi-arrow-right"></i></a> </h6>
                 </div>
             </div>

--- a/layouts/partials/post_preview_top_img_cards.html
+++ b/layouts/partials/post_preview_top_img_cards.html
@@ -1,5 +1,5 @@
 <div class="col-xl-4 col-lg-4 col-md-6 col-sm-6 mb-4">
-    <a href="{{ .Permalink }}" alt="Link to {{ .Title }}">
+    <a href="{{ .Permalink }}">
         <div class="card single-post-card h-100 shadow-effect border">
             {{ if .Params.image }}
             {{ with resources.Get .Params.image }}
@@ -42,8 +42,7 @@
                 </div>
 
                 <div class="read-more-section">
-                    <h6><a href="{{ .Permalink }}" class="text-muted link-underline" alt="Link to {{ .Title }}">{{ i18n "readMore" }} <i
-                        class="bi bi-arrow-right"></i></a> </h6>
+                    <h6 class="text-muted link-underline">{{ i18n "readMore" }} <i class="bi bi-arrow-right"></i></h6>
                 </div>
             </div>
 

--- a/layouts/shortcodes/carousel.html
+++ b/layouts/shortcodes/carousel.html
@@ -13,11 +13,11 @@
                     </div>
                     </div> -->
 
-                <div class="carousel-item {{ if eq $index 0 }} active {{ else }}  carousel-item-not-active {{ end }}"> 
+                <div class="carousel-item {{ if eq $index 0 }} active {{ else }}  carousel-item-not-active {{ end }}">
                     <div class="card ">
                         <div class="row ">
                             <a href="{{ .Permalink }}">
-                            <div class="col-md-8 feature-image "> 
+                            <div class="col-md-8 feature-image ">
                                 <div class="carousel-caption d-md-block carousel-caption">
                                     <span class="badge rounded-pill bg-dark">Featured
                                     <span class="fa-stack fa-sm">
@@ -33,7 +33,7 @@
                                     <h3 class="card-title">{{ .Title }}</h3>
                                     <p class="card-text"> {{ if .Description }} {{ .Description }} {{ end }}</p>
                                     <p class="card-text"><small class="text-muted">
-                                                <a class="post-read-more" href="{{ .Permalink }}">Read more</a></small></p>
+                                                <a class="post-read-more" href="{{ .Permalink }}">{{ i18n "readMore" }}</a></small></p>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
“Read more” string was hardcoded in the templates for some reason, fixed this.

Note that there is also a hardcoded “Link to,” I’ll address this in another pull request.