### PR TITLE
Use .Summary as fallback in post previews

### DIFF
--- a/layouts/partials/post_preview_bottom_card.html
+++ b/layouts/partials/post_preview_bottom_card.html
@@ -20,7 +20,7 @@
                     {{ .Description }}
 
                     {{ else }}
-                    {{ .Content }}
+                    {{ .Summary }}
                     {{ end }}
                 </div>
 

--- a/layouts/partials/post_preview_imgless_card.html
+++ b/layouts/partials/post_preview_imgless_card.html
@@ -20,7 +20,7 @@
                     {{ .Description }}
 
                     {{ else }}
-                    {{ .Content }}
+                    {{ .Summary }}
                     {{ end }}
                 </div>
                 <div class="read-more-section">
@@ -31,4 +31,4 @@
         </a>
         </a>
     </div>
-</div> 
+</div>

--- a/layouts/partials/post_preview_list.html
+++ b/layouts/partials/post_preview_list.html
@@ -18,7 +18,7 @@
                     {{ .Description }}
 
                     {{ else }}
-                    {{ .Content }}
+                    {{ .Summary }}
                     {{ end }}
                 </div>
                 <div class="read-more-section">

--- a/layouts/partials/post_preview_top_img_cards.html
+++ b/layouts/partials/post_preview_top_img_cards.html
@@ -37,7 +37,7 @@
                     {{ .Description }}
 
                     {{ else }}
-                    {{ .Content }}
+                    {{ .Summary }}
                     {{ end }}
                 </div>
 


### PR DESCRIPTION
Currently, if a post doesn’t have a description `.Content` will be displayed as fallback in preview cards. This is bad because preview cards cannot really display much text. Also, links in the post content break the link around the card. This should really use `.Summary` which is generated automatically by Hugo and can be adjusted in length.