### PR TITLE
Attempt to load images from page bundles first

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -4,9 +4,11 @@
     <div class="col-lg-8 offset-lg-2 col-md-10 offset-md-1 ">
 
       <div class="card-image card-image-blog p-0">
-
+        {{ $ := . }}
         {{ with partial "get_image" . }}
-        <img src="{{ .RelPermalink }}" alt="{{ .Title }}" class="card-img-bottom rounded img-fluid lazyload">
+          {{ if not (strings.Contains $.Content $.Params.image) }}
+            <img src="{{ .RelPermalink }}" alt="{{ .Title }}" class="card-img-bottom rounded img-fluid lazyload">
+          {{ end }}
         {{ end }}
 
 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -5,16 +5,8 @@
 
       <div class="card-image card-image-blog p-0">
 
-        {{ if .Params.image }}
-        {{ with resources.Get .Params.image }}
-        {{ with .Err }}
-        {{ warnf "%s" . }}
-        {{ else }}
-
+        {{ with partial "get_image" . }}
         <img src="{{ .RelPermalink }}" alt="{{ .Title }}" class="card-img-bottom rounded img-fluid lazyload">
-        {{ end }}
-
-        {{ end }}
         {{ end }}
 
 
@@ -68,7 +60,7 @@
             </div>
           </div>
 
-         
+
           <div class="col-md-10">
             <div class="card-body p-1.1">
               <p class="p-0 m-0"><small class="text-muted">Written By</small></p>
@@ -80,7 +72,7 @@
                 {{ .Site.Author.name | safeHTML }}
                 {{ end }}
 
-              </p> 
+              </p>
               {{ if .Site.Params.authorInfo }}
               <p class="card-text fs-6  m-0">{{ .Site.Params.authorInfo | safeHTML }}</p>
               {{ end }}

--- a/layouts/partials/get_image.html
+++ b/layouts/partials/get_image.html
@@ -1,0 +1,11 @@
+{{ $img := false }}
+{{ if .Params.image }}
+  {{ with .Resources.Get .Params.image }}
+    {{ $img = . }}
+  {{ else }}
+    {{ with resources.Get .Params.image }}
+      {{ $img = . }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+{{ return $img }}

--- a/layouts/partials/post_preview_bottom_card.html
+++ b/layouts/partials/post_preview_bottom_card.html
@@ -31,17 +31,9 @@
                 </div>
             </div>
 
-            {{ if .Params.image }}
-            {{ with resources.Get .Params.image }}
-            {{ with .Err }}
-            {{ warnf "%s" . }}
-            {{ else }}
-
+            {{ with partial "get_image" . }}
             <img src="{{ ( .Resize " 500x" ).RelPermalink }}" alt="{{ .Title }}"
                 class="card-img-bottom img-fluid lazyload">
-            {{ end }}
-
-            {{ end }}
             {{ end }}
 
             {{ if .Params.video }}

--- a/layouts/partials/post_preview_top_img_cards.html
+++ b/layouts/partials/post_preview_top_img_cards.html
@@ -1,18 +1,11 @@
 <div class="col-xl-4 col-lg-4 col-md-6 col-sm-6 mb-4">
     <a href="{{ .Permalink }}" alt="Link to {{ .Title }}">
         <div class="card single-post-card h-100 shadow-effect border">
-            {{ if .Params.image }}
-            {{ with resources.Get .Params.image }}
-            {{ with .Err }}
-            {{ warnf "%s" . }}
-            {{ else }}
-
+            {{ with partial "get_image" . }}
             <img src="{{ ( .Resize " 500x" ).RelPermalink }}" alt="{{ .Title }}"
                 class="card-img-top img-fluid lazyload">
             {{ end }}
 
-            {{ end }}
-            {{ end }}
             {{ if .Params.video }}
             <video loop autoplay muted playsinline class="img-title">
                 <source src="{{ .Params.video }}">


### PR DESCRIPTION
Currently, lightbi will expect article images to be global. This isn’t optimal for organizing content, that’s why [page bundles](https://gohugo.io/content-management/page-bundles/) exist. With this change, images will be retrieved from the respective page bundles first. Global resources are only being used as fallback.

Note that `Resources.Get` will never return an object with an `.Err` property from what I can tell – it will either produce an image or nothing.