### PR TITLE
Make image placement in preview cards configurable

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -26,15 +26,16 @@ wordCount = false
 useHLJS = true
 socialShare = true
 delayDisqus = true
-showRelatedPosts = true 
+showRelatedPosts = true
 summaryLength  = "9"
 gcse = false
 Lastmod = false
-rss = false 
+rss = false
 pagination = "10"
 hideAuthor = false
 authorInfo = "She was born to be free, let her run wild in her own way and you will never lose her."
 description="Your can add your website description here."
+previewCardImagePlacement = "bottom"
 
 
 [sitemap]

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -7,10 +7,10 @@
         <div class="well">
           {{.}}
         </div>
-      {{ end }} 
+      {{ end }}
       <div class="row">
         {{ range .Paginator.Pages }}
-          {{ partial "post_preview_bottom_card.html" .}}
+          {{ partial "post_preview_card" .}}
         {{ end }}
       </div>
     </div>
@@ -18,13 +18,13 @@
 </div>
 
 <div class="container">
- <div class="row font-sans"> 
+ <div class="row font-sans">
    <div class="col-md-12 mt-10">
-      <nav aria-label="Page navigation"> 
-      <ul class= "pagination justify-content-end">    
-      {{ template "_internal/pagination.html" . }} 
+      <nav aria-label="Page navigation">
+      <ul class= "pagination justify-content-end">
+      {{ template "_internal/pagination.html" . }}
       </ul>
-      </nav> 
+      </nav>
     </div>
   </div>
 </div>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -140,7 +140,7 @@
       {{ range first $num_to_show (where (where .Site.Pages ".Params.tags" "intersect" .Params.tags) "Permalink" "!="
       .Permalink) }}
 
-      {{ partial "post_preview_bottom_card.html" .}}
+      {{ partial "post_preview_card" .}}
       {{ end }}
 
       {{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -14,7 +14,7 @@
 
     {{ $pag := .Paginate (where site.RegularPages "Type" "in" site.Params.mainSections ) 9 }}
     {{ range $pag.Pages }}
-    {{ partial "post_preview_bottom_card" . }}
+    {{ partial "post_preview_card" . }}
     {{ end }}
 
 

--- a/layouts/partials/post_preview_card.html
+++ b/layouts/partials/post_preview_card.html
@@ -1,0 +1,7 @@
+{{ if eq .Site.Params.previewCardImagePlacement "top" }}
+{{ partial "post_preview_top_img_cards" . }}
+{{ else if eq .Site.Params.previewCardImagePlacement "none" }}
+{{ partial "post_preview_imgless_card" . }}
+{{ else }}
+{{ partial "post_preview_bottom_card" . }}
+{{ end }}


### PR DESCRIPTION
This adds a new parameter `previewCardImagePlacement` to determine where the image should be shown on preview cards. Possible values are `top`, `bottom` and `none`. The default (if value is missing or unsupported) is `bottom`, so the current behavior is preserved.