### PR TITLE
Remove leftovers when features are disabled

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -33,6 +33,7 @@
     </div>
   </div>
 
+  {{ if or .Params.tags (not .Site.Params.hideAuthor) ($.Param "socialShare") (ne .Type "page") }}
   <div class="row">
     <div class="col-lg-8 offset-lg-2 col-md-10 offset-md-1">
       <hr class="m-0"/>
@@ -118,9 +119,18 @@
     <div class="col-lg-8 offset-lg-2 col-md-10 offset-md-1 pt-4">
     </div>
   </div>
+  {{ end }}
 </div>
 
 <div class="">
+  {{ $has_related := false }}
+  {{ if .Site.Params.showRelatedPosts }}
+  {{ range first 1 (where (where .Site.Pages ".Params.tags" "intersect" .Params.tags) "Permalink" "!=" .Permalink)
+  }}
+  {{ $has_related = true }}
+  {{ end }}
+
+  {{ if $has_related }}
   <div class="container">
     <div class="row">
       <div class="col-lg-12 col-md-12 mt-3">
@@ -128,25 +138,16 @@
         <hr />
       </div>
 
-      {{ if .Site.Params.showRelatedPosts }}
-      {{ range first 1 (where (where .Site.Pages ".Params.tags" "intersect" .Params.tags) "Permalink" "!=" .Permalink)
-      }}
-      {{ $.Scratch.Set "has_related" true }}
-      {{ end }}
-
-      {{ if $.Scratch.Get "has_related" }}
-
       {{ $num_to_show := .Site.Params.related_content_limit | default 3 }}
       {{ range first $num_to_show (where (where .Site.Pages ".Params.tags" "intersect" .Params.tags) "Permalink" "!="
       .Permalink) }}
 
       {{ partial "post_preview_bottom_card.html" .}}
       {{ end }}
-
-      {{ end }}
-      {{ end }}
     </div>
   </div>
+  {{ end }}
+  {{ end }}
 
   {{ if (.Params.comments) | or (and (or (not (isset .Params "comments")) (eq .Params.comments nil)) (and
   .Site.Params.comments (ne .Type "page"))) }}


### PR DESCRIPTION
Under pages, there is currently a “Read More” heading even if `showRelatedPosts` is `false`. Also, there is a horizontal line even if there is nothing to be separated by it (`socialShare` & Co. are `false`). This change makes sure to remove such leftovers.