### PR TITLE
Do not make header fixed on small screens, make sure navigation menu can be scrolled

### DIFF
--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -1,5 +1,5 @@
 {{ $current := . }}
-<div class="container fixed-top">
+<div class="container fixed-top mw-100">
   <div class="row justify-content-center">
     <div class="col-sm-12 col-md-12 col-lg-10 col-xl-10">
 

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -163,6 +163,12 @@ img {
 
 /* --- Navbar --- */
 
+@media (max-width: 992px) {
+  .fixed-top {
+    position: absolute;
+  }
+}
+
 .navbar-custom {
   background: #ffffff;
   border-bottom: 1px solid #EAEAEA;


### PR DESCRIPTION
The primary motivation behind this change is fixing large navigation menus on small screens. Currently, the bottom of the menu will simply be cut off – it cannot be scrolled to because the header is fixed. However, it’s generally not the best idea to have a fixed header on a small screen, it occupies valuable screen estate.

This change turns header positioning into `absolute` when the screen is too small to display navigation inside the header.