### PR TITLE
Add new card preview layout called middle that places the image between title and preview text.

### DIFF
--- a/layouts/partials/post_preview_card.html
+++ b/layouts/partials/post_preview_card.html
@@ -2,6 +2,8 @@
 {{ partial "post_preview_top_img_cards" . }}
 {{ else if eq .Site.Params.previewCardImagePlacement "none" }}
 {{ partial "post_preview_imgless_card" . }}
+{{ else if eq .Site.Params.previewCardImagePlacement "middle" }}
+{{ partial "post_preview_middle_img_cards" . }}
 {{ else }}
 {{ partial "post_preview_bottom_card" . }}
 {{ end }}

--- a/layouts/partials/post_preview_middle_img_cards.html
+++ b/layouts/partials/post_preview_middle_img_cards.html
@@ -1,0 +1,47 @@
+<div class="col-xl-4 col-lg-4 col-md-6 col-sm-6 mb-4">
+    <a href="{{ .Permalink }}">
+        <div class="card single-post-card h-100 shadow-effect border">
+
+            <h3 class="fw-bold post-title">{{ .Title }}</h3>
+            {{ if .Params.subtitle }}
+            <h3 class="post-subtitle">
+                {{ .Params.subtitle }}
+            </h3>
+            {{ end }}
+            <p class="post-meta">
+                {{ partial "post_meta_notes.html" . }}
+            </p>
+
+            {{ with partial "get_image" . }}
+            <img src="{{ ( .Resize " 500x" ).RelPermalink }}" alt="{{ .Title }}"
+                class="card-img-top img-fluid lazyload">
+            {{ end }}
+
+            {{ if .Params.video }}
+            <video loop autoplay muted playsinline class="img-title">
+                <source src="{{ .Params.video }}">
+            </video>
+            {{ end }}
+            <div class="card-body">
+
+
+
+                
+                {{ print }}
+                <div class="post-entry">
+
+                    {{ if .Description }}
+                    {{ .Description }}
+
+                    {{ else }}
+                    {{ .Summary }}
+                    {{ end }}
+                </div>
+
+                <div class="read-more-section">
+                    <h6 class="text-muted link-underline">{{ i18n "readMore" }} <i class="bi bi-arrow-right"></i></h6>
+                </div>
+            </div>
+        </div>
+    </a>
+</div>


### PR DESCRIPTION
I've added another option to the setting: previewCardImagePlacement = "middle"

This option places the image between the title and the preview text. An example of how this looks can be seen here: https://www.kevssite.com

