### PR TITLE
Fix hugo error message and warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
-# website builed is excluding
+# website build is excluding
 public/
+.hugo_build.lock
+resources/
 
 # Windows image file caches
 Thumbs.db

--- a/exampleSite/content/post/2020/jan/use-this-theme.md
+++ b/exampleSite/content/post/2020/jan/use-this-theme.md
@@ -3,11 +3,11 @@ title: How to use this Hugo theme ?
 date: 2021-02-02
 tags: ["hugo","blog"]
 image : "/img/posts/img-3.jpg"
-Description  : "After downloding the theme, uzip the file and go to the'lightbi-hugo-master' folder. Open the folder in you editor..."
+Description  : "After downloading the theme, unzip the file and go to the'lightbi-hugo-master' folder. Open the folder in you editor..."
 featured: true
 ---
 
-After downloding the theme, uzip the file and go to the 'lightbi-hugo-master' folder. Open the folder in you editor and run the hugo build command as below.
+After downloading the theme, unzip the file and go to the 'lightbi-hugo-master' folder. Open the folder in you editor and run the hugo build command as below.
 
 ```bash
 hugo

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -15,8 +15,11 @@ pygmentsCodefencesGuessSyntax = true
 #googleAnalytics = "XXX"
 enableRobotsTXT = true
 enableGitInfo = false
-Paginate = 6
 summaryLength  = "30"
+ignoreLogs = ['warning-goldmark-raw-html']
+
+[pagination]
+pagerSize = 6
 
 [Params]
 selfHosted = true

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -76,8 +76,6 @@
                  
                 {{ if .Site.Params.Author.name }}
                 {{ .Site.Params.Author.name | safeHTML }}
-                {{ else }}
-                {{ .Site.Author.name | safeHTML }}
                 {{ end }}
 
               </p>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -12,9 +12,9 @@
           class="list-inline list-group list-group-horizontal text-center footer-links d-flex justify-content-center flex-row">
 
           {{ range .Site.Data.lightbi.social.social_icons }}
-          {{- if isset $.Site.Author .id }}
+          {{- if isset $.Site.Params.Author .id }}
           <li>
-            <a href="{{ printf .url (index $.Site.Author .id) }}" title="{{ .title }}" target="_blank">
+            <a href="{{ printf .url (index $.Site.Params.Author .id) }}" title="{{ .title }}" target="_blank">
               <span class="mx-2">
                 <i class="{{ .icon }}"></i>
               </span>
@@ -38,11 +38,11 @@
     <div class="row">
       <div class="col-md-12">
         <p class="credits copyright text-muted">
-          {{ if .Site.Author.name }}
-          {{ if .Site.Author.website }}
-          <a href="{{ .Site.Author.website }}">{{ .Site.Author.name }}</a>
+          {{ if .Site.Params.Author.name }}
+          {{ if .Site.Params.Author.website }}
+          <a href="{{ .Site.Params.Author.website }}">{{ .Site.Params.Author.name }}</a>
           {{ else }}
-          {{ .Site.Author.name }}
+          {{ .Site.Params.Author.name }}
           {{ end }}
           {{ end }}
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -39,7 +39,7 @@
 <meta name="description" content="{{ . }}">
 {{- end }}
 {{ end }}
-{{- with .Site.Author.name }}
+{{- with .Site.Params.Author.name }}
 <meta name="author" content="{{ . }}">
 {{- end }}
 {{- partial "seo/main.html" . }}

--- a/layouts/partials/seo/structured/article.html
+++ b/layouts/partials/seo/structured/article.html
@@ -3,7 +3,7 @@
   "@context": "http://schema.org",
   "@type": "Article",
   "author": {
-    "name" : "{{ if .Params.author -}}{{ .Params.author }}{{- else if .Site.Author.name -}}{{ .Site.Author.name }}{{- end }}"
+    "name" : "{{ if .Site.Params.author -}}{{ .Site.Params.author }}{{- end }}"
   },
   "headline": "{{ .Title }}",
   "description" : "{{ if .Description }}{{ .Description | plainify }}{{ else }}{{if .IsPage}}{{ .Summary | plainify  }}{{ end }}{{ end }}",

--- a/layouts/partials/seo/structured/post.html
+++ b/layouts/partials/seo/structured/post.html
@@ -10,15 +10,10 @@
   },
   "description" : "{{ if .Description }}{{ .Description | plainify }}{{ else }}{{if .IsPage}}{{ .Summary | plainify  }}{{ end }}{{ end }}",
   "inLanguage" : "{{ .Lang }}",
-  {{ if .Params.author -}}
+  {{ if .Site.Params.author -}}
     "author": {
       "@type": "Person",
-      "name": "{{ .Params.author }}"
-  },
-  {{- else if .Site.Author.name -}}
-    "author": {
-      "@type": "Person",
-      "name": "{{ .Site.Author.name }}"
+      "name": "{{ .Site.Params.author }}"
   },
   {{- end }}
   "copyrightYear" : "{{ .Site.Params.since }} - {{ .Site.Lastmod.Format "2006" }}",

--- a/layouts/partials/seo/twitter.html
+++ b/layouts/partials/seo/twitter.html
@@ -8,7 +8,7 @@
   <meta name="twitter:image" content="{{ . | absURL }}" />
 {{- end }}
   <meta name="twitter:card" content="summary" />
-{{- with .Site.Author.twitter }}
+{{- with .Site.Params.Author.twitter }}
   <meta name="twitter:site" content="@{{ . }}" />
   <meta name="twitter:creator" content="@{{ . }}" />
 {{- end }}

--- a/layouts/partials/share-links.html
+++ b/layouts/partials/share-links.html
@@ -16,7 +16,7 @@
     </li>
     <!-- Twitter -->
     <li>
-      <a href="//twitter.com/share?url={{ .Permalink }}&amp;text={{ .Title }}&amp;via={{ .Site.Author }}"
+      <a href="//twitter.com/share?url={{ .Permalink }}&amp;text={{ .Title }}&amp;via={{ .Site.Params.Author }}"
         target="_blank" title="Share on Twitter">
         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" class="bi bi-twitter-x" viewBox="0 0 16 16">
           <path


### PR DESCRIPTION
When running example site with latest hugo version 0.138.0, an error message is thrown:

```
ERROR deprecated: .Site.Author was deprecated in Hugo v0.124.0 and will be removed in Hugo 0.139.0.
Implement taxonomy 'author' or use .Site.Params.Author instead.
```

This PR also fixes some warnings emitted form hugo.