### PR TITLE
Filter the preview summary to prevent in-post images from being displayed in the preview card.

### DIFF
--- a/layouts/partials/post_preview_bottom_card.html
+++ b/layouts/partials/post_preview_bottom_card.html
@@ -17,9 +17,8 @@
                 <div class="post-entry text-secondary">
                     {{ if .Description }}
                     {{ .Description }}
-
                     {{ else }}
-                    {{ .Summary }}
+                    {{ .Summary | plainify }}
                     {{ end }}
                 </div>
 

--- a/layouts/partials/post_preview_middle_img_cards.html
+++ b/layouts/partials/post_preview_middle_img_cards.html
@@ -29,7 +29,7 @@
                     {{ if .Description }}
                     {{ .Description }}
                     {{ else }}
-                    {{ .Summary }}
+                    {{ .Summary | plainify }}
                     {{ end }}
                 </div>
 

--- a/layouts/partials/post_preview_top_img_cards.html
+++ b/layouts/partials/post_preview_top_img_cards.html
@@ -27,9 +27,8 @@
                 <div class="post-entry text-secondary">
                     {{ if .Description }}
                     {{ .Description }}
-
                     {{ else }}
-                    {{ .Summary }}
+                    {{ .Summary | plainify }}
                     {{ end }}
                 </div>
 


### PR DESCRIPTION
Added plainify filter to .summary in the preview card partials template to to prevent in-post images from being displayed in the preview cards. This is to fix the behavious as described in issue #95 